### PR TITLE
Pin herbie-data[extras] and eccodes dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loone_data_prep"
-version = "1.2.1"
+version = "1.2.2"
 description = "Prepare data to run the LOONE model."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -20,8 +20,9 @@ dependencies = [
     "pandas",
     "scipy",
     "geoglows>=2.0.0",
-    "herbie-data[extras]",
+    "herbie-data[extras]==2025.5.0",
     "openmeteo_requests",
     "requests_cache",
-    "retry-requests"
+    "retry-requests",
+    "eccodes==2.42.0"
 ]


### PR DESCRIPTION
- Pins herbie-data to 2025.5.0
- Pins eccodes to 2.42.0
- Fixes curl issues related to unrecognized arguments
- Increases pyproject.toml version to 1.2.2